### PR TITLE
fix linebreak() first line indentation

### DIFF
--- a/src/coldtype/runon/_path.py
+++ b/src/coldtype/runon/_path.py
@@ -279,7 +279,7 @@ class P(Runon):
         line = P()
         lines.append(line)
 
-        for word in self:
+        for idx, word in enumerate(self):
             word.t(-x, 0)
             amb = word.ambit(tx=1, ty=0)
             if amb.pse.x > w+0:
@@ -289,6 +289,10 @@ class P(Runon):
                 x += amb.x
                 line.append(word)
             else:
+                # Align first word of first line to true x
+                if idx == 0:
+                    word.t(-amb.x, 0)
+                    x += amb.x
                 line.append(word)
         
         if leading:

--- a/src/coldtype/runon/path.py
+++ b/src/coldtype/runon/path.py
@@ -340,7 +340,7 @@ class P(Runon):
         line = P()
         lines.append(line)
 
-        for word in self:
+        for idx, word in enumerate(self):
             word.t(-x, 0)
             amb = word.ambit(tx=1, ty=0)
             if amb.pse.x > w+0:
@@ -350,6 +350,10 @@ class P(Runon):
                 x += amb.x
                 line.append(word)
             else:
+                # Align first word of first line to true x
+                if idx == 0:
+                    word.t(-amb.x, 0)
+                    x += amb.x
                 line.append(word)
         
         if leading:


### PR DESCRIPTION
While `stack()`ing some repetitive monospaced text, I noticed an x offset between the first line and the subsequent aligned lines.
### `StSt().wordPens().linebreak()`
#### example
```python
@renderable(rect=(1200, 340), bg=0)
def render(r):
    return (StSt("COLDTYPE " * 8, Font.JBMono(), 100)
        .wordPens()
        .linebreak(r.w)
        .stack()
        .align(r)
        .f(1))
```
#### main (a07c4b6)
<img width="1200" height="368" alt="linebreak before" src="https://github.com/user-attachments/assets/f2010fba-d202-4954-9c09-c0a67e07bd50" />

#### pull request (516d439)
<img width="1200" height="368" alt="linebreak after" src="https://github.com/user-attachments/assets/007f2384-26b7-4b9f-adbe-13f1a490bce6" />

