### PR TITLE
Linux font directories

### DIFF
--- a/packages/coldtype-core/src/coldtype/text/font.py
+++ b/packages/coldtype-core/src/coldtype/text/font.py
@@ -55,8 +55,12 @@ elif on_windows():
         ALL_FONT_DIRS.append(str(Path(localappdata) / "Microsoft/Windows/Fonts/"))
 
 elif on_linux():
-    ALL_FONT_DIRS = ["."]
-    # TODO what are the default linux font installation dirs?
+    ALL_FONT_DIRS = [
+        ".",
+        "/usr/share/fonts",
+        "~/.local/share/fonts",
+        "~/fonts",
+    ]
     pass
 
 FONT_FIND_DEPTH = int(os.environ.get("COLDTYPE_FONT_FIND_DEPTH", 3))

--- a/packages/coldtype-core/src/coldtype/text/font.py
+++ b/packages/coldtype-core/src/coldtype/text/font.py
@@ -59,7 +59,7 @@ elif on_linux():
         ".",
         "/usr/share/fonts",
         "~/.local/share/fonts",
-        "~/fonts",
+        "~/.fonts",
     ]
     pass
 


### PR DESCRIPTION
As the title says, Coldtype lacks defaults for Linux font directories.